### PR TITLE
Fix issues #1 and #2

### DIFF
--- a/lib/thecallr.js
+++ b/lib/thecallr.js
@@ -41,7 +41,7 @@ exports.api = function(login, password, config) {
 		options.auth = login + ':' + password;
 		options.headers = {
 			"Content-Type": "application/json-rpc; charset=utf-8",
-			"Content-Length": json.length
+			"Content-Length": Buffer.byteLength(json)
 		};
 
 		// Proxy agent support
@@ -55,13 +55,17 @@ exports.api = function(login, password, config) {
 		(function(options, json, callback) {
 			// make new request
 			var req = https.request(options, function(res) {
+				var buf = "";
 				if (res.statusCode != 200) {
 					doCallback(callback.error, error("HTTP_CODE_ERROR", -1, {
 						http_code: res.statusCode
 					}));
 				}
 				res.on('data', function(data) {
-					parseData(data.toString(), callback);
+			          buf += data;
+				});
+				res.on('end', function() {
+			          parseData(buf.toString(), callback);
 				});
 			});
 


### PR DESCRIPTION
The http content length was not correct when using Unicode character. Use Buffer.byteLength to compute the correct number of bytes
The data received by https.request are chunked. Must use a buffer to collect all data and only process them at end event.
